### PR TITLE
docs: sync README and docs with current settings.example.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,27 @@ ollama serve          # 別ターミナルで常時起動しておく
 
 ### 2. 必要モデルのダウンロード
 
-| 役割 | モデル | サイズ概算 |
-|---|---|---|
-| テキスト抽出 | `qwen3:8b` | 5.2 GB |
-| テーブル抽出 | `qwen2.5:3b` | 1.9 GB |
-| 図版抽出 (VLM) | `ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227` | 9B class (BF16) |
-| チャンク検証 (VLM) | `qwen2.5vl:7b` | 6.0 GB |
-| 推論オーケストレーター / 回答検証 / DSPy 検証 | `gemma4:latest` | depends on local Ollama manifest |
+推奨モデルは `settings.example.json` の `models.*` を参照してください。
+現在のデフォルト構成 (`settings.example.json` ベース) は次の通りです。
+
+| 役割 | モデル |
+|---|---|
+| テキスト抽出 | `qwen3.5:latest` |
+| テーブル抽出 | `qwen2.5:7b` |
+| 図版抽出 / チャンク検証 (VLM) | `qwen3vl:latest` |
+| 推論オーケストレーター / 回答検証 / DSPy 検証 | `gemma4:latest` |
+| 埋め込み | `kun432/cl-nagoya-ruri-large:latest` |
 
 ```bash
-ollama pull qwen3:8b
-ollama pull qwen2.5:3b
-ollama pull ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227
-ollama pull qwen2.5vl:7b
+ollama pull qwen3.5:latest
+ollama pull qwen2.5:7b
+ollama pull qwen3vl:latest
 ollama pull gemma4:latest
+ollama pull kun432/cl-nagoya-ruri-large:latest
 ```
 
-注: Ricoh VLM は利用規約への同意が必要な場合があります。`ollama pull` が利用環境で失敗する場合は、`models.vision_extraction` を従来の `qwen2.5vl:7b` に戻して運用してください。
+モデルは `settings.json` または CLI オプションで上書きできます。
+詳細は [docs/CONFIG_SETUP.md](docs/CONFIG_SETUP.md) を参照してください。
 
 ### 3. Python 依存関係のインストール
 
@@ -77,28 +81,36 @@ cp settings.example.json settings.json
 ```json
 {
   "ollama": {
-    "base_url": "http://localhost:11434"
+    "base_url": "http://localhost:11434",
+    "request_timeout_seconds": 120
   },
   "models": {
-    "text_extraction": "qwen3:8b",
-    "table_extraction": "qwen2.5:3b",
-    "vision_extraction": "ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227",
-    "chunk_validator": "qwen2.5vl:7b",
+    "text_extraction": "qwen3.5:latest",
+    "table_extraction": "qwen2.5:7b",
+    "vision_extraction": "qwen3vl:latest",
+    "chunk_validator": "qwen3vl:latest",
     "orchestrator": "gemma4:latest",
     "answer_validator": "gemma4:latest",
     "dspy_lm": "gemma4:latest",
-    "embedder": "kun432/cl-nagoya-ruri-large"
+    "embedder": "kun432/cl-nagoya-ruri-large:latest"
   },
   "embedder": {
     "backend": "ollama",
-    "query_prefix": null,
-    "passage_prefix": null,
-    "batch_size": 32
+    "batch_size": 32,
+    "max_input_chars": 800,
+    "retry_trim_enabled": true,
+    "retry_trim_min_chars": 128
+  },
+  "pipeline": {
+    "text_passthrough": true,
+    "figure_ocr_only": true
   }
 }
 ```
 
-デフォルトは `kun432/cl-nagoya-ruri-large`（Ollama バックエンド）です。
+完全な設定リファレンスは `settings.example.json` および [docs/CONFIG_SETUP.md](docs/CONFIG_SETUP.md) を参照してください。
+
+デフォルトは `kun432/cl-nagoya-ruri-large:latest`（Ollama バックエンド）です。
 sentence-transformers を使う場合は `settings.example.json` を参考に切り替えてください。
 
 詳細は [docs/CONFIG_SETUP.md](docs/CONFIG_SETUP.md) を参照してください。
@@ -112,7 +124,8 @@ LANGFUSE_BASE_URL=https://cloud.langfuse.com  # または後方互換エイリ�
 ```
 
 Langfuse のキーが未設定でも処理は継続します。
-Langfuse トレースにはモデル名として Ollama モデル名 (`qwen3:8b` 等) が記録されます。
+Langfuse トレースにはモデル名として Ollama モデル名が記録されます。
+Langfuse SDK バージョンが互換でない場合は no-op に切り替わり、診断情報がログに出力されます。
 
 ### 6. OCR 前提
 
@@ -186,33 +199,30 @@ python app.py pipeline ./in/sample.pdf "要点を3つで要約して"
 
 ## アーキテクチャ概要
 
-注: 下記のモデル ID は `settings.json` または CLI オプションで上書き可能です。既定値はセットアップ節と `src/core/config.py` の定義を参照してください。
+使用モデルは `settings.json` の `models.*` または CLI オプションで指定します。
+推奨値は `settings.example.json` を参照してください。
 
 ```
 app.py (CLI)
   └── pipeline.py
         ├── parser.py          — PDF parse (pdfplumber + PyMuPDF + OCR)
         ├── agents/
-        │   ├── TextAgent      — qwen3:8b   テキスト抽出
-        │   ├── TableAgent     — qwen2.5:3b テーブル抽出
-        │   ├── VisionAgent    — ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227 図版解析 (VLM)
-        │   ├── ChunkValidatorAgent   — qwen2.5vl:7b CHECKPOINT A
-        │   ├── ReasoningOrchestratorAgent — gemma4:latest 回答生成
-        │   └── AnswerValidatorAgent  — gemma4:latest (DSPy) CHECKPOINT B
+        │   ├── TextAgent      — テキスト抽出 (models.text_extraction)
+        │   ├── TableAgent     — テーブル抽出 (models.table_extraction)
+        │   ├── VisionAgent    — 図版解析 VLM (models.vision_extraction)
+        │   ├── ChunkValidatorAgent   — CHECKPOINT A (models.chunk_validator)
+        │   ├── ReasoningOrchestratorAgent — 回答生成 (models.orchestrator)
+        │   └── AnswerValidatorAgent  — CHECKPOINT B / DSPy (models.answer_validator)
         ├── store.py           — ChromaDB + BM25 ハイブリッド検索 (RRF)
         └── integrations/
-            ├── langfuse.py    — Langfuse v3 OTel トレース
+            ├── langfuse.py    — Langfuse v3 OTel トレース (SDK 互換時)
             └── dspy_adapter.py — DSPy + Ollama 設定ヘルパー
 ```
 
 すべての LLM 呼び出しは `ollama.Client.chat()` 経由で行われます。
 モデルのロード / アンロードおよび VRAM 管理は Ollama サーバーが担います。
-埋め込みモデルは `ollama` バックエンド（デフォルト: `kun432/cl-nagoya-ruri-large`）
+埋め込みモデルは `ollama` バックエンド（デフォルト: `kun432/cl-nagoya-ruri-large:latest`）
 または `sentence_transformers` バックエンド（例: `intfloat/multilingual-e5-small`）から選択できます。
-
-VLM の段階導入方針:
-- Phase 1: `vision_extraction` を Ricoh VLM に置換
-- Phase 2: 品質評価後に `chunk_validator` 置換を検討
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Agentic RAG Architecture
 
-Last updated: 2026-04-08
+Last updated: 2026-04-16
 
 この文書は、現在サポートされている Sequential + Ollama 構成だけを説明します。削除済みの CrewAI、LangGraph、MLX 経路は対象外です。
 
@@ -170,6 +170,7 @@ DSPy 連携は `AnswerValidatorAgent` で使われます。
 ## 8. Observability
 
 `LangfuseTracer` が trace / span / score を記録します。環境変数が未設定でも処理は継続します。
+Langfuse SDK バージョンが互換でない場合は自動的に no-op トレースに切り替わり、管理の診断情報が WARNING レベルでログに出力されます。
 
 - ingest trace
 - query trace

--- a/docs/CONFIG_SETUP.md
+++ b/docs/CONFIG_SETUP.md
@@ -1,6 +1,6 @@
 # Configuration Setup Guide
 
-Last updated: 2026-04-08
+Last updated: 2026-04-16
 
 このガイドは、現行の Sequential + Ollama runtime で有効な設定だけを整理したものです。
 
@@ -45,6 +45,7 @@ cp settings.example.json settings.json
 
 - `ollama`
   - `base_url`
+  - `request_timeout_seconds` (Ollama API 呼び出しのタイムアウト秒数、既定: `120`)
 - `models`
   - `text_extraction`
   - `table_extraction`
@@ -59,10 +60,15 @@ cp settings.example.json settings.json
   - `query_prefix` (null = backend 既定値を使用)
   - `passage_prefix` (null = backend 既定値を使用)
   - `batch_size`
+  - `max_input_chars` (埋め込み入力の最大文字数、超過時に trim してリトライ; 既定: `800`)
+  - `retry_trim_enabled` (trim リトライの有効化; 既定: `true`)
+  - `retry_trim_min_chars` (trim リトライの最低文字数; 既定: `128`)
 - `pipeline`
   - `max_context_chunks`
   - `embedder_batch_size`
   - `chunk_size`
+  - `text_passthrough` (テキストチャンクを LLM に通さず原文のまま採用; 既定: `true`)
+  - `figure_ocr_only` (図版チャンクを LLM 解析せず OCR テキストのみ採用; 既定: `true`)
 - `cache`
   - `enable_hf_cache`
   - `cache_dir`
@@ -212,29 +218,31 @@ python -c "from src.core.config import config; print(config.get('ocr.engine'))"
 
 現時点でサポートされる runtime は Sequential + Ollama のみです。
 
-## 11. Ricoh VLM rollout (recommended)
+## 11. VLM の選択
 
-`ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227` を導入する場合は段階導入を推奨します。
+`models.vision_extraction` と `models.chunk_validator` はどちらも VLM を使います。
+現在の推奨値は `settings.example.json` の `qwen3vl:latest` です。
 
-1. Phase 1
-- `models.vision_extraction` のみ Ricoh VLM に変更
-- `models.chunk_validator` は `qwen2.5vl:7b` のまま維持
-
-2. Phase 2
-- Phase 1 の品質・速度評価が安定したら `models.chunk_validator` も置換を検討
-
-例:
+利用可能な VLM であれば自由に切り替えられます。例えば Ricoh VLM (`ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227`) を使う場合:
 
 ```json
 {
   "models": {
     "vision_extraction": "ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227",
-    "chunk_validator": "qwen2.5vl:7b"
+    "chunk_validator": "ricoh-ai/Qwen-3-VL-Ricoh-8B-20260227"
   }
 }
 ```
 
+注意: Ricoh VLM は利用規約への同意が必要な場合があります。`ollama pull` が失敗する場合は `qwen3vl:latest` に戻してください。
+
 ロールバック:
 
-- `models.vision_extraction` を `qwen2.5vl:7b` に戻すだけで復旧可能です。
-- Ricoh VLM が利用環境で pull/起動できない場合も同様に既存モデルへ戻してください。
+```json
+{
+  "models": {
+    "vision_extraction": "qwen3vl:latest",
+    "chunk_validator": "qwen3vl:latest"
+  }
+}
+```

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,6 +1,6 @@
 # ライブラリ・フレームワーク解説
 
-Last updated: 2026-04-08
+Last updated: 2026-04-16
 
 このドキュメントは、Agentic RAG for Multi-Model PDF Extraction が依存する主要なフレームワーク・ライブラリについて説明します。
 各項目では「概要」「このアプリでの用途」「役割」を記述します。
@@ -133,8 +133,9 @@ BERT 系モデルを用いて文・段落を高品質なベクトルに変換し
 |-----------|------|
 | `src/core/embedder.py` | `SentenceTransformerEmbedder` として実装されており、`ChunkStore` のデフォルト埋め込み backend として使用される |
 
-デフォルトモデルは `kun432/cl-nagoya-ruri-large` (Ollama backend)。
-クエリには `"クエリ: "` プレフィックス、文書には `"文章: "` プレフィックスを付与して encode します。
+デフォルトモデルは `kun432/cl-nagoya-ruri-large:latest` (Ollama backend、`embedder.backend: "ollama"`として使用)。
+`sentence_transformers` バックエンドに切り替える場合は `settings.example.json` を参照してください。
+ruri モデルの場合、クエリには `"クエリ: "` 、文書には `"文章: "` プレフィックスを付与して encode します。
 
 **役割**
 


### PR DESCRIPTION
## 概要\n\nREADME.md と docs/ を現行の `settings.example.json` および `src/core/config.py` defaults に合わせて改定しました。\n\n## 変更内容\n\n### README.md\n- モデル表と `ollama pull` コマンドを現在の推奨値に更新 (`qwen3.5:latest`, `qwen3vl:latest` ほか; 旧 `qwen3:8b` / `qwen2.5:3b` / Ricoh VLM as default を削除)\n- settings.json サンプルに新しいキーを追加: `request_timeout_seconds`, `text_passthrough`, `figure_ocr_only`, `max_input_chars`, `retry_trim_enabled`, `retry_trim_min_chars`\n- アーキテクチャ図のモデル ID をロールベースのラベル (`models.text_extraction` 等) に統一し、ハードコードを排除\n- Langfuse ノートに SDK 非互換時 no-op + 診断ログ出力の説明を追加\n\n### docs/CONFIG_SETUP.md\n- `Last updated` を 2026-04-16 に更新\n- Section 2.2 Main keys に未記載キーを追加:\n  - `ollama.request_timeout_seconds`\n  - `embedder.max_input_chars`, `retry_trim_enabled`, `retry_trim_min_chars`\n  - `pipeline.text_passthrough`, `figure_ocr_only`\n- Section 11 を「Ricoh VLM rollout (recommended)」から「VLM の選択」に改訂: `qwen3vl:latest` をデフォルトとして扱い、Ricoh VLM は任意の代替例として位置づけ\n\n### docs/ARCHITECTURE.md\n- `Last updated` を 2026-04-16 に更新\n- Observability 節に Langfuse SDK 非互換時の no-op フォールバック動作を追記\n\n### docs/library.md\n- `Last updated` を 2026-04-16 に更新\n- sentence-transformers 節のデフォルトモデル説明を `kun432/cl-nagoya-ruri-large:latest` (Ollama backend) に修正