### PR TITLE
feat: Phase 1-2 extraction quality improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ python app.py pipeline ./in/sample.pdf "要点を3つで要約して"
 | `--validate` / `--no-validate` | CHECKPOINT A (ingest) / CHECKPOINT B (query) の有効化 |
 | `--enable-figure-aware-fallback` | parser の figure-aware テーブル fallback を有効化 |
 | `--lazy-agents` | 抽出エージェントをチャンクごとにロード/アンロード (VRAM 節約、低速化) |
+| `--quality-mode` | 抽出品質優先モード (text_passthrough を無効化) |
+| `--fast-mode` | 速度優先モード (text_passthrough を有効化) |
 | `--session-id` | Langfuse トレースのグループ ID |
 | `--storage-dir` | ChromaDB 保存先 |
 | `--output` | 監査レポートの出力先 |

--- a/app.py
+++ b/app.py
@@ -87,6 +87,8 @@ def cmd_ingest(args: argparse.Namespace) -> int:
     log.info(f"Ingesting: {pdf_path.name}")
     log.info(f"{'=' * 70}\n")
 
+    _apply_runtime_pipeline_mode(args)
+
     pipeline = AgenticRAGPipeline.build(
         text_model=args.text_model,
         table_model=args.table_model,
@@ -131,6 +133,8 @@ def cmd_query(args: argparse.Namespace) -> int:
         Exit code (0 for success, non-zero for error)
     """
     question = args.question
+
+    _apply_runtime_pipeline_mode(args)
 
     pipeline = AgenticRAGPipeline.build(
         text_model=args.text_model,
@@ -201,6 +205,8 @@ def cmd_pipeline(args: argparse.Namespace) -> int:
         return 1
 
     question = args.question
+
+    _apply_runtime_pipeline_mode(args)
 
     pipeline = AgenticRAGPipeline.build(
         text_model=args.text_model,
@@ -277,6 +283,20 @@ def cmd_pipeline(args: argparse.Namespace) -> int:
 
     log.info("\nPipeline complete!\n")
     return 0
+
+
+def _apply_runtime_pipeline_mode(args: argparse.Namespace) -> None:
+    """Apply runtime extraction mode flags from CLI arguments.
+
+    Quality mode forces text extraction through the TextAgent.
+    Fast mode enables text passthrough for lower latency.
+    """
+    if getattr(args, "quality_mode", False):
+        config.set("pipeline.text_passthrough", False)
+        log.info("Pipeline mode: quality (text_passthrough=False)")
+    elif getattr(args, "fast_mode", False):
+        config.set("pipeline.text_passthrough", True)
+        log.info("Pipeline mode: fast (text_passthrough=True)")
 
 
 # ═══════════════════════════════════════════════════════════
@@ -484,6 +504,19 @@ Examples:
             action="store_true",
             default=False,
             help="Load/unload extraction agents per chunk (saves VRAM, slower)",
+        )
+        mode_group = perf_group.add_mutually_exclusive_group()
+        mode_group.add_argument(
+            "--quality-mode",
+            action="store_true",
+            default=False,
+            help="Prefer extraction quality by disabling text passthrough",
+        )
+        mode_group.add_argument(
+            "--fast-mode",
+            action="store_true",
+            default=False,
+            help="Prefer speed by enabling text passthrough",
         )
 
     return parser

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -238,6 +238,26 @@ class ConfigLoader:
                 return default
         return value if value is not None else default
 
+    def set(self, key: str, value: Any) -> None:
+        """Set config value by dot notation key at runtime.
+
+        Args:
+            key: Dot-separated config key
+            value: Value to set
+        """
+        parts = key.split(".")
+        if not parts:
+            return
+
+        node: dict[str, Any] = self.config
+        for part in parts[:-1]:
+            current = node.get(part)
+            if not isinstance(current, dict):
+                current = {}
+                node[part] = current
+            node = current
+        node[parts[-1]] = value
+
 
 # Global config instance
 config = ConfigLoader()

--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -90,6 +90,7 @@ class PDFParser:
         self._available_tesseract_languages_loaded = False
         self._easyocr_reader: Any | None = None
         self._last_ocr_metadata: dict[str, Any] | None = None
+        self._last_parse_table_metrics: list[dict[str, Any]] = []
         if self.OCR_PREWARM_EASYOCR and self.OCR_ENGINE == "easyocr":
             self._get_easyocr_reader()
 
@@ -105,6 +106,7 @@ class PDFParser:
         """
         pdf_path = Path(pdf_path)
         chunks: list[RawChunk] = []
+        self._last_parse_table_metrics = []
         doc_fitz = pymupdf.open(str(pdf_path))
         doc_plumb = pdfplumber.open(str(pdf_path))
 
@@ -193,6 +195,7 @@ class PDFParser:
                     elif reject_reason is not None:
                         rejected_reasons[reject_reason] = rejected_reasons.get(reject_reason, 0) + 1
                 metrics = self._build_table_metrics(table_candidates, accepted_tables, rejected_reasons)
+                self._last_parse_table_metrics.append({"page_num": page_idx + 1, **metrics})
                 log.info(
                     "Page %d: table metrics total=%d default=%d fallback=%d accepted=%d rejected=%d",
                     page_idx + 1,
@@ -225,6 +228,10 @@ class PDFParser:
 
         log.info("Parsed %d raw chunks from %s", len(chunks), pdf_path.name)
         return chunks
+
+    def get_last_parse_table_metrics(self) -> list[dict[str, Any]]:
+        """Return table diagnostics captured during the last parse call."""
+        return [dict(entry) for entry in self._last_parse_table_metrics]
 
     def _should_skip_fitz_word_extraction(self, plumb_words: list[dict[str, Any]], image_count: int) -> bool:
         """Return True when a page is likely native PDF text and fitz word extraction is unnecessary."""

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -267,6 +267,7 @@ class AgenticRAGPipeline:
                     accepted=accepted,
                     output_dir=audit_output_dir,
                     render_page_previews=self.audit_render_page_previews,
+                    parser_table_metrics=self.parser.get_last_parse_table_metrics(),
                 )
 
             log.info("=" * 70 + "\n")

--- a/src/utils/audit.py
+++ b/src/utils/audit.py
@@ -24,6 +24,7 @@ def save_chunk_audit(
     accepted: list[ProcessedChunk],
     output_dir: str | Path,
     render_page_previews: bool = True,
+    parser_table_metrics: list[dict[str, Any]] | None = None,
 ) -> dict[str, Path]:
     """Persist audit artifacts for visual review of extracted chunks."""
     pdf_path = Path(pdf_path)
@@ -62,6 +63,7 @@ def save_chunk_audit(
     audit_data = {
         "pdf_file": pdf_path.name,
         "pdf_path": os.path.relpath(pdf_path, start=output_dir).replace("\\", "/"),
+        "parser_table_metrics": parser_table_metrics or [],
         "pages": [
             {
                 "page_num": page_num,
@@ -208,6 +210,10 @@ def _build_html(audit_data: dict[str, Any]) -> str:
     .diff-del {{ background:#fee2e2; color:#991b1b; text-decoration:line-through; display:block; }}
     .diff-ctx {{ color:#6b7280; display:block; }}
     .empty-state {{ border: 1px dashed var(--border); border-radius: 20px; padding: 24px; background: rgba(255,255,255,0.6); color: var(--muted); }}
+    .metrics {{ border: 1px solid var(--border); border-radius: 20px; padding: 18px; background: rgba(255,255,255,0.72); margin-bottom: 24px; }}
+    .metrics table {{ width: 100%; border-collapse: collapse; font-size: 14px; }}
+    .metrics th, .metrics td {{ border-bottom: 1px solid var(--border); padding: 8px; text-align: left; }}
+    .metrics th {{ color: var(--muted); font-weight: 600; }}
     @media (max-width: 980px) {{ .layout {{ grid-template-columns: 1fr; }} .detail {{ position: static; }} }}
   </style>
 </head>
@@ -220,6 +226,7 @@ def _build_html(audit_data: dict[str, Any]) -> str:
       <div class=\"chunk-list\" id=\"chunk-list\"></div>
     </aside>
     <main class=\"content\">
+      <section class="metrics" id="metrics"></section>
       <section class=\"detail\" id=\"detail\">
         <strong>Chunk を選択すると詳細を表示します。</strong>
       </section>
@@ -298,6 +305,51 @@ __PAYLOAD__
         };
         host.appendChild(button);
       });
+    }
+
+    function renderMetrics() {
+      const host = document.getElementById("metrics");
+      const metrics = audit.parser_table_metrics || [];
+      if (!metrics.length) {
+        host.innerHTML = '<strong>Parser table metrics</strong><p>メトリクスは記録されていません。</p>';
+        return;
+      }
+
+      const rows = metrics.map((metric) => {
+        const reasons = Object.entries(metric.rejected_reasons || {})
+          .map(([key, value]) => `${escapeHtml(key)}:${value}`)
+          .join(", ");
+        return `
+          <tr>
+            <td>${metric.page_num}</td>
+            <td>${metric.total_candidates}</td>
+            <td>${metric.default_candidates}</td>
+            <td>${metric.fallback_candidates}</td>
+            <td>${metric.accepted_candidates}</td>
+            <td>${metric.rejected_candidates}</td>
+            <td>${reasons || "-"}</td>
+          </tr>
+        `;
+      }).join("");
+
+      host.innerHTML = `
+        <strong>Parser table metrics</strong>
+        <p>ページ別のテーブル候補判定サマリです。</p>
+        <table>
+          <thead>
+            <tr>
+              <th>page</th>
+              <th>total</th>
+              <th>default</th>
+              <th>fallback</th>
+              <th>accepted</th>
+              <th>rejected</th>
+              <th>reasons</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      `;
     }
 
     function visibleChunks() {
@@ -417,6 +469,7 @@ __PAYLOAD__
     }
 
     renderFilters();
+    renderMetrics();
     renderChunkList();
     renderPages();
     if (chunks.length) {

--- a/tests/test_app_cli_modes.py
+++ b/tests/test_app_cli_modes.py
@@ -1,0 +1,57 @@
+"""Tests for CLI runtime extraction mode toggles."""
+
+import argparse
+
+from app import _apply_runtime_pipeline_mode, create_parser
+
+
+class _DummyConfig:
+    """Minimal config stub for runtime override tests."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, object]] = []
+
+    def set(self, key: str, value: object) -> None:
+        self.calls.append((key, value))
+
+
+def test_cli_mode_flags_are_exclusive() -> None:
+    parser = create_parser()
+
+    args = parser.parse_args(["ingest", "sample.pdf", "--quality-mode"])
+    assert args.quality_mode is True
+    assert args.fast_mode is False
+
+    args = parser.parse_args(["ingest", "sample.pdf", "--fast-mode"])
+    assert args.fast_mode is True
+    assert args.quality_mode is False
+
+
+def test_apply_runtime_pipeline_mode_sets_quality(monkeypatch) -> None:
+    dummy = _DummyConfig()
+    monkeypatch.setattr("app.config", dummy)
+
+    args = argparse.Namespace(quality_mode=True, fast_mode=False)
+    _apply_runtime_pipeline_mode(args)
+
+    assert dummy.calls == [("pipeline.text_passthrough", False)]
+
+
+def test_apply_runtime_pipeline_mode_sets_fast(monkeypatch) -> None:
+    dummy = _DummyConfig()
+    monkeypatch.setattr("app.config", dummy)
+
+    args = argparse.Namespace(quality_mode=False, fast_mode=True)
+    _apply_runtime_pipeline_mode(args)
+
+    assert dummy.calls == [("pipeline.text_passthrough", True)]
+
+
+def test_apply_runtime_pipeline_mode_no_flag_does_nothing(monkeypatch) -> None:
+    dummy = _DummyConfig()
+    monkeypatch.setattr("app.config", dummy)
+
+    args = argparse.Namespace(quality_mode=False, fast_mode=False)
+    _apply_runtime_pipeline_mode(args)
+
+    assert dummy.calls == []

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -187,3 +187,63 @@ def test_save_chunk_audit_skips_page_preview_rendering_when_disabled(tmp_path: P
     assert audit_data["pages"] == []
     assert audit_data["pdf_path"] == "../sample.pdf"
     assert "ページプレビューは生成されていません。" in html
+
+
+def test_save_chunk_audit_persists_parser_table_metrics(tmp_path: Path) -> None:
+    """Audit report should retain parser table diagnostics for later comparisons."""
+    pdf_path = tmp_path / "sample.pdf"
+    document = pymupdf.open()
+    page = document.new_page(width=200, height=300)
+    page.insert_text((24, 48), "Audit me")
+    document.save(pdf_path)
+    document.close()
+
+    raw = RawChunk(
+        chunk_type=ChunkType.TEXT,
+        page_num=1,
+        source_file=pdf_path.name,
+        raw_content="Audit me",
+        bbox=(20.0, 30.0, 120.0, 70.0),
+        page_width=200.0,
+        page_height=300.0,
+        source_preview="Audit me",
+    )
+    processed = ProcessedChunk(
+        chunk_type=ChunkType.TEXT,
+        page_num=1,
+        source_file=pdf_path.name,
+        bbox=raw.bbox,
+        page_width=raw.page_width,
+        page_height=raw.page_height,
+        source_preview=raw.source_preview,
+        structured_text="Audit me",
+        intuition_summary="Short text block",
+        confidence=0.95,
+    )
+    parser_metrics = [
+        {
+            "page_num": 1,
+            "total_candidates": 4,
+            "default_candidates": 2,
+            "fallback_candidates": 2,
+            "accepted_candidates": 1,
+            "rejected_candidates": 3,
+            "rejected_reasons": {"too_sparse": 2, "overlaps_figure": 1},
+        }
+    ]
+
+    paths = save_chunk_audit(
+        pdf_path=pdf_path,
+        extracted=[(raw, processed)],
+        accepted=[processed],
+        output_dir=tmp_path / "out",
+        parser_table_metrics=parser_metrics,
+    )
+
+    audit_data = json.loads(paths["json"].read_text(encoding="utf-8"))
+    html = paths["html"].read_text(encoding="utf-8")
+
+    assert audit_data["parser_table_metrics"] == parser_metrics
+    assert "Parser table metrics" in html
+    assert '"parser_table_metrics"' in html
+    assert '"too_sparse": 2' in html

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -151,6 +151,26 @@ def test_build_table_metrics_aggregates_candidate_sources_and_reasons() -> None:
     assert metrics["rejected_reasons"] == {"fallback_low_table_signal": 1, "too_sparse": 1}
 
 
+def test_get_last_parse_table_metrics_returns_copy() -> None:
+    parser = PDFParser()
+    parser._last_parse_table_metrics = [
+        {
+            "page_num": 1,
+            "total_candidates": 2,
+            "default_candidates": 1,
+            "fallback_candidates": 1,
+            "accepted_candidates": 1,
+            "rejected_candidates": 1,
+            "rejected_reasons": {"too_sparse": 1},
+        }
+    ]
+
+    captured = parser.get_last_parse_table_metrics()
+    captured[0]["accepted_candidates"] = 999
+
+    assert parser._last_parse_table_metrics[0]["accepted_candidates"] == 1
+
+
 class _DummyCandidate:
     def __init__(self, bbox: tuple[float, float, float, float]):
         self.bbox = bbox


### PR DESCRIPTION
Phase 1 - Parser table diagnostics:
- Capture per-page table metrics in PDFParser._last_parse_table_metrics
- Expose via get_last_parse_table_metrics() (returns shallow copy)
- Pass metrics through pipeline to save_chunk_audit()
- Persist to audit JSON and render as table in HTML viewer

Phase 2 - Runtime quality/speed mode controls:
- Add ConfigLoader.set() for dot-notation runtime config override
- Add --quality-mode / --fast-mode mutually exclusive CLI flags to ingest, query, and pipeline subcommands
- Add _apply_runtime_pipeline_mode() to apply flags before pipeline build
- Update README options table

Tests: 48 passing (new test_app_cli_modes.py + extended test_parser/audit)